### PR TITLE
#18 - Made timeout configurable which enables test top run much faster

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,5 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env()}.exs"
+
+config :timeout, prod: 5000, test: 1000

--- a/lib/dms/service.ex
+++ b/lib/dms/service.ex
@@ -11,8 +11,7 @@ defmodule DMS.Service do
 
   @server __MODULE__
   @supervisor DMS.Service.Supervisor
-  # TODO Make timeout configurable.
-  @timeout 5 * 1000
+  @timeout Application.fetch_env!(:timeout, :"#{Mix.env()}")
 
   @doc """
   Signals service is alive.

--- a/test/dms_test.exs
+++ b/test/dms_test.exs
@@ -23,10 +23,11 @@ defmodule DMSTest do
     end
   end
 
-  test "service should die after 5 seconds" do
+  test "service should die after the configured interval" do
     id = "test-svc-2"
     assert :pong = DMS.ping(id)
-    Process.sleep(5_010)
+    timeout = Application.fetch_env!(:timeout, :"#{Mix.env()}") + 1
+    Process.sleep(timeout)
     refute DMS.alive?(id)
   end
 end


### PR DESCRIPTION
Proposed fixe for #18 

Not sure if using the `config.exs` is right for this. Something smells to me however I'll put it up regardless and let it be reviewed. Thought it was a bit too heavy to use a `enviro.exs` config files.

Help wanted:

I get this when running the tests.. These will need silenced before a merge can happen. Or quite possibly this is the wrong approach for this type of application.

![Screen Shot 2019-05-12 at 16 06 03](https://user-images.githubusercontent.com/356955/57584213-9c8cbf00-74d0-11e9-9437-643b37b362f5.png)